### PR TITLE
Improve sidebar selection, uncomment components, and limit upcoming birthdays

### DIFF
--- a/src/app/dashboard/home/page.tsx
+++ b/src/app/dashboard/home/page.tsx
@@ -86,7 +86,7 @@ export default async function Home() {
             </CardTitle>
           </CardHeader>
           <CardContent className="px-4 md:px-6">
-            {/* <BirthdayTable /> */}
+            <BirthdayTable />
           </CardContent>
         </Card>
       </div>

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -72,7 +72,7 @@ export function AppSidebar() {
           <SidebarGroupContent>
             <SidebarMenu>
               {items.map((item) => {
-                const isSelected = pathName === item.url;
+                const isSelected = pathName.includes(item.url);
                 return (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton
@@ -80,8 +80,7 @@ export function AppSidebar() {
                       size="lg"
                       className={cn(
                         "rounded-full p-4 hover:bg-white/50",
-                        isSelected &&
-                          `bg-primary text-primary-foreground`,
+                        isSelected && "bg-primary text-primary-foreground",
                       )}
                     >
                       <a

--- a/src/features/dashboard/home/components/birthday-table.tsx
+++ b/src/features/dashboard/home/components/birthday-table.tsx
@@ -29,7 +29,7 @@ export function BirthdayTable() {
   const todaysBirthdays = birthdays?.filter((b) => b.isToday) ?? [];
   const upcomingBirthdays = birthdays?.filter((b) => !b.isToday) ?? [];
 
-  const limitedUpComingBirthdays = upcomingBirthdays?.reverse().slice(0, 5);
+  const limitedUpComingBirthdays = [...upcomingBirthdays]?.reverse().slice(0, 5);
   const todayTable = useReactTable({
     data: todaysBirthdays,
     columns,

--- a/src/features/dashboard/home/components/commission-and-sales-cards.tsx
+++ b/src/features/dashboard/home/components/commission-and-sales-cards.tsx
@@ -5,7 +5,7 @@ import { SalesCard } from "@/features/dashboard/home/components/sales-card";
 export function CommissionAndSalesCards() {
   return (
     <div className="flex w-full flex-col items-center gap-2 md:flex-row">
-      {/* <CommissionCard title="Commission" range={{ min: 4200, max: 12000 }} /> */}
+      <CommissionCard title="Commission" range={{ min: 4200, max: 12000 }} />
       <SalesCard />
     </div>
   );

--- a/src/features/dashboard/home/server/db/home.ts
+++ b/src/features/dashboard/home/server/db/home.ts
@@ -1,9 +1,9 @@
 "use server";
 import { createDrizzleSupabaseClient } from "@/db/db";
 import { profile, roles, userRoles, users } from "@/db/schema";
-import type { User } from "@/features/dashboard/user-management/server/db/user-management";
+
 import { createClient } from "@/lib/supabase/server";
-import { tryCatch } from "@/lib/utils";
+
 import { desc, eq, getTableColumns } from "drizzle-orm";
 
 export async function getUpComingBDs() {
@@ -21,8 +21,15 @@ export async function getUpComingBDs() {
       })
       .from(profile)
       .innerJoin(users, eq(users.id, profile.userId))
-      .orderBy(profile.dob);
-    return birthdays.map((row) => {
+      .orderBy(desc(profile.dob));
+
+    return birthdays.filter(
+      (row) => {
+        const dob = new Date(row.dob);
+        return dob>=today ;
+      }
+    ).map((row) => {
+
       const dob = new Date(row.dob);
       const isToday =
         dob.getDate() === today.getDate() &&


### PR DESCRIPTION
Enhance URL matching in the sidebar item selection logic. Uncomment the `BirthdayTable` component in the Home view and the `CommissionCard` in the Commission and Sales Cards. Ensure that the list of upcoming birthdays is correctly limited to five entries.